### PR TITLE
Deprecated: localStream.stop()

### DIFF
--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -311,7 +311,7 @@
       if(document.visibilityState === 'hidden') {
         // Disconnect the camera.
         if(localStream !== undefined) {
-          localStream.stop();
+          localStream.getVideoTracks()[0].stop();
           localStream = undefined;
         }
       }


### PR DESCRIPTION
localStream.stop() is deprecated. Use `getVideoTrack()` instead and call `stop()` on it